### PR TITLE
fix: convert path to `CString` in `rknn_init`

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -320,13 +320,13 @@ pub mod prelude {
         /// If successful, returns an `Rknn` instance; otherwise, returns an `Error`.
         pub fn rknn_init<P: AsRef<std::path::Path>>(model_path: P) -> Result<Self, Error> {
             let mut ret = Rknn { context: 0 };
-            let path_ref = model_path.as_ref();
-            let model_path_cstr_ptr = path_ref.to_string_lossy().as_ptr();
+            let path_str = model_path.as_ref().to_string_lossy();
+            let path_cstr = CString::new(path_str.as_ref()).unwrap();
 
             unsafe {
                 let result = super::rknn_init(
                     &mut ret.context,
-                    model_path_cstr_ptr as *mut std::ffi::c_void,
+                    path_cstr.as_ptr() as *mut std::ffi::c_void,
                     0,
                     0,
                     null_mut(),


### PR DESCRIPTION
`rknn_init` 里面的路径未转成 `CString` 导致没有 null terminated，下面的代码实际试图打开的路径是 `/tmp/yolov10n.rknnsomestring`

```rust
use rknn_rs::prelude::*;

fn main() {
    let _ = Rknn::rknn_init("/tmp/yolov10n.rknn");
    std::hint::black_box("some string");
}
```
<img width="680" height="97" alt="image" src="https://github.com/user-attachments/assets/3539a272-bce9-447a-8fe6-672bf3da7be0" />
